### PR TITLE
Handle missing auth middleware

### DIFF
--- a/src/Http/Middleware/Require2FA.php
+++ b/src/Http/Middleware/Require2FA.php
@@ -18,6 +18,12 @@ class Require2FA
      */
     public function handle($request, Closure $next)
     {
+        if (!auth()->user()) {
+            session()->put('intended.url', $request->getRequestUri());
+            return redirect()->to(route('login'))->withErrors([
+                'email' => ['Authentication required'],
+            ]);
+        }
         if (!auth()->user()->google2fa_secret) {
             session()->put('intended.url', $request->getRequestUri());
             return redirect()->to(route('rapid2fa.enable'))->with(

--- a/src/Http/Middleware/Require2FA.php
+++ b/src/Http/Middleware/Require2FA.php
@@ -19,7 +19,6 @@ class Require2FA
     public function handle($request, Closure $next)
     {
         if (!auth()->user()) {
-            session()->put('intended.url', $request->getRequestUri());
             return redirect()->to(route('login'))->withErrors([
                 'email' => ['Authentication required'],
             ]);


### PR DESCRIPTION
If someone runs a route through the `require2fa` middleware without also including the `auth` middleware (not recommended) then throw them to the login page instead of the enable page.