### PR TITLE
Handle missing lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ can copy or use as a guide to make your own.
 
 ## Requirements
 * `php >= 7.2`
-* `laravel/framework >=5.8`
+* `laravel/framework >= 5.8`
 * `google2fa-laravel`
 
 This package is intended for use in apps using basic Laravel Auth support

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": "^7.2",
         "pragmarx/google2fa-laravel": "^1.0",
-        "laravel/framework": "5.8.*"
+        "laravel/framework": "5.8.*",
+        "doctrine/dbal": "^2.9"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/enable.blade.php
+++ b/resources/views/enable.blade.php
@@ -16,19 +16,26 @@
 
                     <div class="panel-body">
                         <div style="text-align: center;">
-                            <div class="alert alert-success" role="alert">
-                                Scan the QR code using a standard two-factor
-                                auth app such as Google Authenticator:
-                            </div>
-                            <br />
+                            @if ($image)
+                                <div class="alert alert-success" role="alert">
+                                    Scan the QR code using a standard two-factor
+                                    auth app such as Google Authenticator:
+                                </div>
+                                <br />
 
-                            <div>
-                                <img alt="Image of QR barcode" src="{{ $image }}" />
-                            </div>
+                                <div>
+                                    <img alt="Image of QR barcode" src="{{ $image }}" />
+                                </div>
+                            @elseif (app()->isLocal())
+                                <div class="alert alert-danger" role="alert">
+                                    You are probably missing the <b>php-imagick</b> extension.
+                                </div>
+                            @endif
 
                             <div style="text-align: center;">
-                                If you're unable to use QR barcodes, you can
-                                enter the following code into your app:
+                                If you're unable to use QR barcodes or you do
+                                not see one above, you can enter the following
+                                code into your app:<br/>
                                 <code style="color: rgb(122, 9, 9); font-size: 40px;">{{ $secret }}</code>
                             </div>
 

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -43,7 +43,7 @@
                             <label for="rapid2fa" class="col-md-4 col-form-label text-md-right">{{ __('Two-Factor Code') }}</label>
 
                             <div class="col-md-6">
-                                <input id="rapid2fa" type="text" class="form-control{{ $errors->has('rapid2fa') ? ' is-invalid' : '' }}" name="rapid2fa" value="" autofocus>
+                                <input id="rapid2fa" type="text" class="form-control{{ $errors->has('rapid2fa') ? ' is-invalid' : '' }}" name="rapid2fa" value="" autocomplete="off" autofocus>
                                 @if ($errors->has('rapid2fa'))
                                     <span class="invalid-feedback" role="alert">
                                         <strong>{{ $errors->first('rapid2fa') }}</strong>

--- a/src/Http/Controllers/Rapid2FAController.php
+++ b/src/Http/Controllers/Rapid2FAController.php
@@ -34,12 +34,15 @@ class Rapid2FAController extends Controller
     {
         $user = $request->user();
         $secret = $this->generateSecret();
-        $imageDataUri = Google2FA::getQRCodeInline(
-            $request->getHttpHost(),
-            $user->email,
-            $secret,
-            200
-        );
+        $imageDataUri = null;
+        if (extension_loaded('imagick')) {
+            $imageDataUri = Google2FA::getQRCodeInline(
+                $request->getHttpHost(),
+                $user->email,
+                $secret,
+                200
+            );
+        }
 
         return view('rapid2fa::enable', [
             'image' => $imageDataUri,


### PR DESCRIPTION
* Don't throw errors if the `imagick` extension isn't available
* Don't autocomplete the QR code input field
* Add `doctrine/dbal` requirement for the migration `down()` call